### PR TITLE
Remove typing on variable

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 History
 =======
 
+1.0.1 (2024-01-11)
+------------------
+
+* Remove typing from a variable since it crashes on Python 3.5
+
 1.0.0 (2023-01-04)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ servedocs: docs ## compile the docs watching for changes
 	watchmedo shell-command -p '*.rst' -c '$(MAKE) -C docs html' -R -D .
 
 release: dist ## package and upload a release
-	twine upload dist/*
+	twine upload --repository stilpy dist/*
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist

--- a/README.rst
+++ b/README.rst
@@ -6,9 +6,6 @@ Stilpy
 .. image:: https://img.shields.io/pypi/v/stilpy.svg
         :target: https://pypi.python.org/pypi/stilpy
 
-.. image:: https://img.shields.io/travis/fesanmar/stilpy.svg
-        :target: https://travis-ci.org/fesanmar/stilpy
-
 .. image:: https://readthedocs.org/projects/stilpy/badge/?version=latest
         :target: https://stilpy.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
@@ -16,12 +13,6 @@ Stilpy
 .. image:: https://pyup.io/repos/github/fesanmar/Stilpy/shield.svg
      :target: https://pyup.io/repos/github/fesanmar/Stilpy/
      :alt: Updates
-     
-.. image:: https://img.shields.io/lgtm/alerts/g/fesanmar/Stilpy.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/fesanmar/Stilpy/alerts/
-   
-.. image:: https://img.shields.io/lgtm/grade/python/g/fesanmar/Stilpy.svg?logo=lgtm&logoWidth=18
-   :target: https://lgtm.com/projects/g/fesanmar/Stilpy/context:python
 
 
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,4 @@
-pip==21.1
+pip==23.3
 bump2version==1.0.1
 wheel==0.38.1
 watchdog==0.10.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 1.0.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     test_suite='tests',
     tests_require=test_requirements,
     url='https://github.com/fesanmar/stilpy',
-    version='1.0.0',
+    version='1.0.1',
     zip_safe=False,
 )

--- a/stilpy/__init__.py
+++ b/stilpy/__init__.py
@@ -4,7 +4,7 @@
 
 __author__ = """Felipe Santa-Cruz"""
 __email__ = 'fesanmar@gmail.com'
-__version__ = '1.0.0'
+__version__ = '1.0.1'
 __all__ = ['timeinterval', 'timegaps']
 
 from stilpy.timegaps import TimeGaps, TimeInterval

--- a/stilpy/timegaps.py
+++ b/stilpy/timegaps.py
@@ -319,7 +319,7 @@ class TimeGaps:
     
     @staticmethod
     def _join_args_in_dict(start_el: Dict[str, Any], end_el: Dict[str, Any]) -> Dict[str, Any]:
-        new_args: {str, Any} = {}
+        new_args = {}
         for key, val in start_el.items():
             if key in end_el and end_el[key] != val:
                 new_args[key] = (val, end_el[key])


### PR DESCRIPTION
The typing on a variable crashes on Python 3.5. This commit remove the offending typing.